### PR TITLE
Remove prediction randomness for reproducible signals

### DIFF
--- a/stock_direction_trader.py
+++ b/stock_direction_trader.py
@@ -274,28 +274,18 @@ class StockDirectionTrader:
         if len(features.shape) == 2:
             features = np.expand_dims(features, axis=0)
         
-        # Get prediction probability
+        # Get prediction probability and use it directly without random noise
         pred_prob = self.model.predict(features, verbose=0)
-        raw_confidence = pred_prob[0][0]
-        
-        # Add randomness to predictions to avoid always predicting the same direction
-        # Use a lower threshold for UP predictions to encourage more diversity
-        # This is a form of exploration in reinforcement learning
-        
-        # Add noise to the prediction probability
-        noise_factor = 0.05  # 5% noise
-        noisy_confidence = raw_confidence + np.random.uniform(-noise_factor, noise_factor)
-        
-        # Ensure it's still a valid probability
-        noisy_confidence = max(0.01, min(0.99, noisy_confidence))
-        
-        # Use a threshold of 0.48 to encourage more DOWN predictions
-        prediction = 1 if noisy_confidence > 0.51 else 0
-        
-        # Log the original and adjusted confidence
-        logger.debug(f"Raw confidence: {raw_confidence:.4f}, Noisy confidence: {noisy_confidence:.4f}, Prediction: {prediction}")
-        
-        return prediction, noisy_confidence
+        confidence = float(pred_prob[0][0])
+
+        # Determine signal based on raw model confidence
+        signal = int(confidence > 0.5)
+
+        logger.debug(
+            f"Confidence: {confidence:.4f}, Prediction: {signal}"
+        )
+
+        return signal, confidence
 
     def generate_signal(self, prediction, confidence, current_position):
         """

--- a/tests/test_predict_determinism.py
+++ b/tests/test_predict_determinism.py
@@ -1,0 +1,18 @@
+import numpy as np
+from stock_direction_trader import StockDirectionTrader
+
+
+class DummyModel:
+    def predict(self, features, verbose=0):
+        return np.array([[0.7]])
+
+
+def test_predict_direction_deterministic():
+    trader = StockDirectionTrader("TEST")
+    trader.model = DummyModel()
+    features = np.zeros((trader.lookback_days, 5))
+
+    first = trader.predict_direction(features)
+    second = trader.predict_direction(features)
+
+    assert first == second


### PR DESCRIPTION
## Summary
- Remove random noise from `predict_direction` and rely solely on raw model confidence
- Return deterministic signal and confidence, and log prediction data
- Add regression test ensuring `predict_direction` is deterministic

## Testing
- `PYTHONDONTWRITEBYTECODE=1 python -m pytest tests/test_predict_determinism.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689cadcb396c8329b70d604bcff31c23