### PR TITLE
Ensure chronological validation in training

### DIFF
--- a/tests/test_training_order.py
+++ b/tests/test_training_order.py
@@ -1,0 +1,26 @@
+import types
+import numpy as np
+import tensorflow as tf
+from stock_direction_trader import StockDirectionTrader
+
+
+def test_training_no_shuffle_and_chronological_split(monkeypatch):
+    trader = StockDirectionTrader("TEST", lookback_days=1)
+
+    # small dummy dataset
+    X = np.random.rand(30, 1, 1)
+    y = np.random.randint(0, 2, size=30)
+
+    captured = {}
+    dummy_history = types.SimpleNamespace(history={"val_loss": [0.0]})
+
+    def fake_fit(self, *args, **kwargs):
+        captured["shuffle"] = kwargs.get("shuffle")
+        return dummy_history
+
+    monkeypatch.setattr(tf.keras.Model, "fit", fake_fit)
+
+    trader.train_model(X, y, epochs=1, batch_size=4)
+
+    assert captured["shuffle"] is False
+    assert max(trader.last_train_indices) < min(trader.last_val_indices)


### PR DESCRIPTION
## Summary
- prevent data leakage by explicitly splitting the last 20% of training data as validation and disabling shuffling
- add TimeSeriesSplit-based hyperparameter search and store train/validation indices
- introduce unit test verifying no shuffling and chronological validation order

## Testing
- `PYTHONPATH=. pytest tests/test_training_order.py -q`

------
https://chatgpt.com/codex/tasks/task_e_689cadd1371883299d2eeaa8921b0b50