### PR TITLE
Use source trading dates for data preparation

### DIFF
--- a/models/beta2.py
+++ b/models/beta2.py
@@ -7,17 +7,33 @@ import yfinance as yf
 import joblib
 import matplotlib.pyplot as plt
 from datetime import datetime, timedelta
-from sklearn.preprocessing import MinMaxScaler, StandardScaler
-import tensorflow as tf
-from tensorflow.keras.models import Sequential, Model, load_model #type: ignore
-from tensorflow.keras.layers import Dense, LSTM, Dropout, GRU, Bidirectional #type: ignore  
-from tensorflow.keras.layers import Conv1D, MaxPooling1D, BatchNormalization #type: ignore
-from tensorflow.keras.layers import Input, concatenate #type: ignore
-from tensorflow.keras.optimizers import Adam #type: ignore
-from tensorflow.keras.callbacks import EarlyStopping, ModelCheckpoint, ReduceLROnPlateau #type: ignore
-from sklearn.model_selection import TimeSeriesSplit, train_test_split
-from sklearn.metrics import mean_squared_error, mean_absolute_error, r2_score
-import ta
+try:
+    from sklearn.preprocessing import MinMaxScaler, StandardScaler
+    from sklearn.model_selection import TimeSeriesSplit, train_test_split
+    from sklearn.metrics import mean_squared_error, mean_absolute_error, r2_score
+except ImportError:  # pragma: no cover
+    MinMaxScaler = StandardScaler = TimeSeriesSplit = train_test_split = None
+    mean_squared_error = mean_absolute_error = r2_score = None
+try:
+    import tensorflow as tf
+    from tensorflow.keras.models import Sequential, Model, load_model  # type: ignore
+    from tensorflow.keras.layers import Dense, LSTM, Dropout, GRU, Bidirectional  # type: ignore
+    from tensorflow.keras.layers import Conv1D, MaxPooling1D, BatchNormalization  # type: ignore
+    from tensorflow.keras.layers import Input, concatenate  # type: ignore
+    from tensorflow.keras.optimizers import Adam  # type: ignore
+    from tensorflow.keras.callbacks import EarlyStopping, ModelCheckpoint, ReduceLROnPlateau  # type: ignore
+except ImportError:  # pragma: no cover
+    tf = None
+    Sequential = Model = load_model = None
+    Dense = LSTM = Dropout = GRU = Bidirectional = None
+    Conv1D = MaxPooling1D = BatchNormalization = None
+    Input = concatenate = None
+    Adam = None
+    EarlyStopping = ModelCheckpoint = ReduceLROnPlateau = None
+try:
+    import ta
+except ImportError:  # pragma: no cover
+    ta = None
 import warnings
 warnings.filterwarnings('ignore')
 
@@ -59,8 +75,8 @@ class StockPredictor:
         os.makedirs(os.path.dirname(self.model_path), exist_ok=True)
         
         # Initialize scalers with improved parameters
-        self.scaler_price = MinMaxScaler(feature_range=(0, 1))
-        self.scaler_features = StandardScaler()  # Z-score normalization for features
+        self.scaler_price = MinMaxScaler(feature_range=(0, 1)) if MinMaxScaler else None
+        self.scaler_features = StandardScaler() if StandardScaler else None  # Z-score normalization for features
         
         logger.info(f"Initialized StockPredictor with {self.model_type} model type, {self.prediction_days} prediction days")
         

--- a/tests/test_calendar_alignment.py
+++ b/tests/test_calendar_alignment.py
@@ -1,0 +1,42 @@
+import os
+import sys
+from datetime import datetime
+
+import pandas as pd
+import yfinance as yf
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from stock_direction_trader import StockDirectionTrader
+
+
+def _load_local_data():
+    path = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data', 'SPY_5yr.csv')
+    cols = ['Date', 'Close', 'High', 'Low', 'Open', 'Volume']
+    df = pd.read_csv(path, skiprows=3, names=cols, parse_dates=['Date'])
+    df.set_index('Date', inplace=True)
+    return df
+
+
+def test_calendar_alignment(monkeypatch):
+    # Use local CSV data to avoid network dependency
+    base_df = _load_local_data()
+
+    def fake_download(symbol, start=None, end=None, progress=False):
+        df = base_df.copy()
+        if start:
+            df = df[df.index >= pd.to_datetime(start)]
+        if end:
+            df = df[df.index <= pd.to_datetime(end)]
+        return df
+
+    monkeypatch.setattr(yf, 'download', fake_download)
+
+    symbol = 'SPY'
+    start = datetime(2020, 1, 1)
+    end = datetime(2020, 12, 31)
+    trader = StockDirectionTrader(symbol)
+    prepared = trader.prepare_data(start, end)
+
+    fetched = yf.download(symbol, start=start, end=end, progress=False)
+    intersection_len = len(prepared.index.intersection(fetched.index))
+    assert intersection_len == len(prepared.index)


### PR DESCRIPTION
## Summary
- fetch historical data using yfinance's native DateTimeIndex and remove business-day reindexing
- add S&P 500 comparison and retain trading dates in `prepare_data`
- add calendar alignment test using local sample data
- make heavy ML dependencies optional for lightweight environments

## Testing
- `pytest tests/test_calendar_alignment.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689cade15c888329a4c083a938d25b80